### PR TITLE
feat: 질문 목록, 상세 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,19 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/i6/honterview/HonterviewApplication.java
+++ b/src/main/java/com/i6/honterview/HonterviewApplication.java
@@ -2,7 +2,9 @@ package com.i6.honterview;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class HonterviewApplication {
 

--- a/src/main/java/com/i6/honterview/config/QueryDslConfig.java
+++ b/src/main/java/com/i6/honterview/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.i6.honterview.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/i6/honterview/controller/QuestionController.java
+++ b/src/main/java/com/i6/honterview/controller/QuestionController.java
@@ -1,0 +1,41 @@
+package com.i6.honterview.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.i6.honterview.dto.PageResponse;
+import com.i6.honterview.dto.QuestionDetailResponse;
+import com.i6.honterview.dto.QuestionResponse;
+import com.i6.honterview.response.ApiResponse;
+import com.i6.honterview.service.QuestionService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/questions")
+public class QuestionController {
+
+	private final QuestionService questionService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse> getQuestions(
+		@RequestParam(value = "page", defaultValue = "1") int page,
+		@RequestParam(value = "size", defaultValue = "10") int size,
+		@RequestParam(value = "query", required = false) String query
+	) {
+		PageResponse<QuestionResponse> response = questionService.getQuestions(page, size, query);
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse> getQuestionById(@PathVariable Long id) {
+		QuestionDetailResponse response = questionService.getQuestionById(id);
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+}

--- a/src/main/java/com/i6/honterview/domain/Admin.java
+++ b/src/main/java/com/i6/honterview/domain/Admin.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "admin")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class Admin {
+public class Admin extends BaseEntity {
 
 	@Id
 	@Column(name = "id", nullable = false)

--- a/src/main/java/com/i6/honterview/domain/Answer.java
+++ b/src/main/java/com/i6/honterview/domain/Answer.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "answer")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class Answer {
+public class Answer extends BaseEntity {
 
 	@Id
 	@Column(name = "id", nullable = false)

--- a/src/main/java/com/i6/honterview/domain/AnswerHeart.java
+++ b/src/main/java/com/i6/honterview/domain/AnswerHeart.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "answer_heart")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class AnswerHeart {
+public class AnswerHeart extends BaseEntity {
 
 	@Id
 	@Column(name = "id", nullable = false)

--- a/src/main/java/com/i6/honterview/domain/BaseEntity.java
+++ b/src/main/java/com/i6/honterview/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.i6.honterview.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+	@Column(name = "created_at")
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/i6/honterview/domain/Category.java
+++ b/src/main/java/com/i6/honterview/domain/Category.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "category")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class Category {
+public class Category extends BaseEntity {
 
 	@Id
 	@Column(name = "id", nullable = false)

--- a/src/main/java/com/i6/honterview/domain/Interview.java
+++ b/src/main/java/com/i6/honterview/domain/Interview.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "interview")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class Interview {
+public class Interview extends BaseEntity {
 
 	@Id
 	@Column(name = "id", nullable = false)

--- a/src/main/java/com/i6/honterview/domain/Member.java
+++ b/src/main/java/com/i6/honterview/domain/Member.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "member")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
 
 	@Id
 	@Column(name = "id", nullable = false)

--- a/src/main/java/com/i6/honterview/domain/Question.java
+++ b/src/main/java/com/i6/honterview/domain/Question.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "question")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class Question {
+public class Question extends BaseEntity {
 
 	@Id
 	@Column(name = "id", nullable = false)

--- a/src/main/java/com/i6/honterview/domain/QuestionHeart.java
+++ b/src/main/java/com/i6/honterview/domain/QuestionHeart.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "question_heart")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class QuestionHeart {
+public class QuestionHeart extends BaseEntity {
 
 	@Id
 	@Column(name = "id", nullable = false)

--- a/src/main/java/com/i6/honterview/dto/PageResponse.java
+++ b/src/main/java/com/i6/honterview/dto/PageResponse.java
@@ -1,0 +1,43 @@
+package com.i6.honterview.dto;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+	int currentPage,
+	int pageSize,
+	long totalElements,
+	int startIndex,
+	int endIndex,
+	boolean hasPreviousPage,
+	boolean hasNextPage,
+	List<T> data
+) {
+	public static <T, R> PageResponse<R> of(Page<T> page, Function<T, R> converter) {
+		int currentPage = page.getNumber() + 1;
+		int pageSize = page.getSize();
+		long totalElements = page.getTotalElements();
+		int totalPages = page.getTotalPages();
+
+		int startIndex = (currentPage - 1) * pageSize + 1;
+		int endIndex = Math.min(currentPage * pageSize, (int)totalElements);
+
+		boolean hasPreviousPage = currentPage > 1;
+		boolean hasNextPage = currentPage < totalPages;
+
+		List<R> content = page.getContent().stream().map(converter).toList();
+
+		return new PageResponse<>(
+			currentPage,
+			pageSize,
+			totalElements,
+			startIndex,
+			endIndex,
+			hasPreviousPage,
+			hasNextPage,
+			content
+		);
+	}
+}

--- a/src/main/java/com/i6/honterview/dto/QuestionDetailResponse.java
+++ b/src/main/java/com/i6/honterview/dto/QuestionDetailResponse.java
@@ -1,0 +1,9 @@
+package com.i6.honterview.dto;
+
+import com.i6.honterview.domain.Question;
+
+public record QuestionDetailResponse(Long id, String content) {
+	public static QuestionDetailResponse from(Question question) {
+		return new QuestionDetailResponse(question.getId(), question.getContent());
+	}
+}

--- a/src/main/java/com/i6/honterview/dto/QuestionResponse.java
+++ b/src/main/java/com/i6/honterview/dto/QuestionResponse.java
@@ -1,0 +1,10 @@
+package com.i6.honterview.dto;
+
+import com.i6.honterview.domain.Question;
+
+public record QuestionResponse(Long id, String content) {
+
+	public QuestionResponse(Question question) {
+		this(question.getId(), question.getContent());
+	}
+}

--- a/src/main/java/com/i6/honterview/dto/QuestionResponse.java
+++ b/src/main/java/com/i6/honterview/dto/QuestionResponse.java
@@ -4,7 +4,7 @@ import com.i6.honterview.domain.Question;
 
 public record QuestionResponse(Long id, String content) {
 
-	public QuestionResponse(Question question) {
-		this(question.getId(), question.getContent());
+	public static QuestionResponse from(Question question) {
+		return new QuestionResponse(question.getId(), question.getContent());
 	}
 }

--- a/src/main/java/com/i6/honterview/exception/CustomException.java
+++ b/src/main/java/com/i6/honterview/exception/CustomException.java
@@ -1,0 +1,11 @@
+package com.i6.honterview.exception;
+
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/i6/honterview/exception/ErrorCode.java
+++ b/src/main/java/com/i6/honterview/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.i6.honterview.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.i6.honterview.response.ErrorResponse;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+	QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_NOT_FOUND", "존재하지 않는 질문입니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+
+	public ErrorResponse getErrorResponse() {
+		return new ErrorResponse(code, message);
+	}
+}

--- a/src/main/java/com/i6/honterview/repository/QuestionQueryDslReposiotoryImpl.java
+++ b/src/main/java/com/i6/honterview/repository/QuestionQueryDslReposiotoryImpl.java
@@ -1,0 +1,46 @@
+package com.i6.honterview.repository;
+
+import static com.i6.honterview.domain.QQuestion.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import com.i6.honterview.domain.Question;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestionQueryDslReposiotoryImpl implements QuestionQueryDslRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<Question> findQuestionsByKeywordWithPage(Pageable pageable, String query) {
+		BooleanExpression searchCondition = StringUtils.hasText(query) ?
+			question.content.contains(query) : null;
+
+		List<Question> questions = queryFactory
+			.selectFrom(question)
+			.where(searchCondition)
+			.orderBy(question.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		JPAQuery<Long> countQuery = queryFactory
+			.select(question.count())
+			.from(question)
+			.where(searchCondition);
+
+		return PageableExecutionUtils.getPage(questions, pageable, countQuery::fetchOne);
+	}
+}

--- a/src/main/java/com/i6/honterview/repository/QuestionQueryDslRepository.java
+++ b/src/main/java/com/i6/honterview/repository/QuestionQueryDslRepository.java
@@ -1,0 +1,10 @@
+package com.i6.honterview.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.i6.honterview.domain.Question;
+
+public interface QuestionQueryDslRepository {
+	Page<Question> findQuestionsByKeywordWithPage(Pageable pageable, String query);
+}

--- a/src/main/java/com/i6/honterview/repository/QuestionRepository.java
+++ b/src/main/java/com/i6/honterview/repository/QuestionRepository.java
@@ -1,0 +1,8 @@
+package com.i6.honterview.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.i6.honterview.domain.Question;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/com/i6/honterview/response/ApiResponse.java
+++ b/src/main/java/com/i6/honterview/response/ApiResponse.java
@@ -1,0 +1,11 @@
+package com.i6.honterview.response;
+
+public record ApiResponse<T>(String message, T data) {
+	public static <T> ApiResponse<T> ok(T result) {
+		return new ApiResponse<>("ok", result);
+	}
+
+	public static <T> ApiResponse<T> created(T result) {
+		return new ApiResponse<>("created", result);
+	}
+}

--- a/src/main/java/com/i6/honterview/response/ErrorResponse.java
+++ b/src/main/java/com/i6/honterview/response/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.i6.honterview.response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+public class ErrorResponse {
+
+	private final String errorCode; // ex) TOO_LONG_PRODUCT_DESCRIPTION
+	private final String errorMessage;
+	private final Map<String, String> validation = new HashMap<>();
+
+	public ErrorResponse(String errorCode, String errorMessage) {
+		this.errorCode = errorCode;
+		this.errorMessage = errorMessage;
+	}
+
+	public void addValidation(String field, String message) {
+		validation.put(field, message);
+	}
+}

--- a/src/main/java/com/i6/honterview/service/QuestionService.java
+++ b/src/main/java/com/i6/honterview/service/QuestionService.java
@@ -1,0 +1,44 @@
+package com.i6.honterview.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.i6.honterview.domain.Question;
+import com.i6.honterview.dto.PageResponse;
+import com.i6.honterview.dto.QuestionDetailResponse;
+import com.i6.honterview.dto.QuestionResponse;
+import com.i6.honterview.exception.CustomException;
+import com.i6.honterview.exception.ErrorCode;
+import com.i6.honterview.repository.QuestionQueryDslRepository;
+import com.i6.honterview.repository.QuestionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class QuestionService {
+
+	private final QuestionQueryDslRepository questionQueryDslRepository;
+	private final QuestionRepository questionRepository;
+
+	@Transactional(readOnly = true)
+	public PageResponse<QuestionResponse> getQuestions(int page, int size, String query) {
+		// TODO : 좋아요 순 정렬, 카테고리 목록별 검색 추가
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Question> questions = questionQueryDslRepository.findQuestionsByKeywordWithPage(pageable, query);
+		return PageResponse.of(questions, QuestionResponse::new);
+	}
+
+	@Transactional(readOnly = true)
+	public QuestionDetailResponse getQuestionById(Long id) {
+		// TODO : 답변 목록 추가
+		Question question = questionRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
+		return QuestionDetailResponse.from(question);
+	}
+
+}

--- a/src/main/java/com/i6/honterview/service/QuestionService.java
+++ b/src/main/java/com/i6/honterview/service/QuestionService.java
@@ -30,7 +30,7 @@ public class QuestionService {
 		// TODO : 좋아요 순 정렬, 카테고리 목록별 검색 추가
 		Pageable pageable = PageRequest.of(page - 1, size);
 		Page<Question> questions = questionQueryDslRepository.findQuestionsByKeywordWithPage(pageable, query);
-		return PageResponse.of(questions, QuestionResponse::new);
+		return PageResponse.of(questions, QuestionResponse::from);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
## 구현 기능
- 질문 목록 조회 GET /questions
- 질문 상세 조회 GET /questions/{id}
- queryDsl 설정
- BaseEntity 적용
- 커스텀 exception, 공통 response 규격 추가

## 코멘트
- 최소한의 기능만 구현했습니다! PR 단위를 작게 나누기 위해 다음 PR에 아래 기능 추가하겠습니다 🙌
- 추가해야 할 기능
- [ ] 카테고리 목록별 목록 조회 
- [ ] 좋아요 순, 최신순 동적 정렬
- [ ] 질문 상세 조회시 답변 상세 목록 포함
resolve: #3
