### PR TITLE
feat: 시큐리티 설정 및 카카오 Oauth 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // TODO : 추후 제거
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // TODO : 추후 제거
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/i6/honterview/config/WebConfig.java
+++ b/src/main/java/com/i6/honterview/config/WebConfig.java
@@ -1,0 +1,26 @@
+package com.i6.honterview.config;
+
+import java.util.Arrays;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins(getAllowOrigins())
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+			.allowCredentials(true);
+	}
+
+	private String[] getAllowOrigins() {
+		return Arrays.asList(
+			"http://127.0.0.1:3000",
+			"http://localhost:3000"
+		).toArray(String[]::new);
+	}
+}

--- a/src/main/java/com/i6/honterview/config/WebSecurityConfig.java
+++ b/src/main/java/com/i6/honterview/config/WebSecurityConfig.java
@@ -1,0 +1,103 @@
+package com.i6.honterview.config;
+
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.*;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import com.i6.honterview.security.service.Oauth2UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+	private final Oauth2UserService oauth2UserService;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	/**
+	 * permitAll 권한을 가진 엔드포인트에 적용되는 SecurityFilterChain
+	 */
+	@Bean
+	public SecurityFilterChain securityFilterChainPermitAll(HttpSecurity http) throws Exception {
+		configureCommonSecuritySettings(http);
+		http.securityMatchers(matchers -> matchers.requestMatchers(requestPermitAll()))
+			.authorizeHttpRequests(authorize -> authorize
+				.anyRequest()
+				.permitAll());
+		return http.build();
+	}
+
+	private RequestMatcher[] requestPermitAll() {
+		List<RequestMatcher> requestMatchers = List.of(
+
+			// DOCS
+			antMatcher("/swagger-ui/**"),
+			antMatcher("/swagger-ui"),
+			antMatcher("/swagger-ui.html"),
+			antMatcher("/swagger/**"),
+			antMatcher("/swagger-resources/**"),
+			antMatcher("/v3/api-docs/**"),
+			antMatcher("/webjars/**"),
+
+			// H2-CONSOLE
+			antMatcher("/h2-console/**")
+		);
+		return requestMatchers.toArray(RequestMatcher[]::new);
+	}
+
+	/**
+	 * OAuth 관련 엔드포인트에 적용되는 SecurityFilterChain 입니다.
+	 */
+	@Bean
+	public SecurityFilterChain securityFilterChainOAuth(HttpSecurity http) throws Exception {
+		configureCommonSecuritySettings(http);
+		http
+			.securityMatchers(matchers -> matchers
+				.requestMatchers(
+					antMatcher("/login"),
+					antMatcher("/login/oauth2/code/kakao"),
+					antMatcher("/oauth2/authorization/kakao")
+				))
+			.authorizeHttpRequests(authorize -> authorize
+				.anyRequest()
+				.permitAll())
+			.oauth2Login(
+				(oauth) ->
+					oauth.userInfoEndpoint(
+							(endpoint) -> endpoint.userService(oauth2UserService)
+						)
+			//			.successHandler(oauthSuccessHandler)
+			);
+		return http.build();
+	}
+
+
+	private void configureCommonSecuritySettings(HttpSecurity http) throws Exception {
+		http.csrf(AbstractHttpConfigurer::disable)
+			.anonymous(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.rememberMe(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
+			.headers(headers -> headers
+				.frameOptions(frameOptions -> frameOptions.disable()))
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+	}
+}

--- a/src/main/java/com/i6/honterview/config/WebSecurityConfig.java
+++ b/src/main/java/com/i6/honterview/config/WebSecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
+import com.i6.honterview.security.service.OAuth2AuthenticationSuccessHandler;
 import com.i6.honterview.security.service.Oauth2UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class WebSecurityConfig {
 
 	private final Oauth2UserService oauth2UserService;
+	private final OAuth2AuthenticationSuccessHandler oauthSuccessHandler;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -83,7 +85,7 @@ public class WebSecurityConfig {
 					oauth.userInfoEndpoint(
 							(endpoint) -> endpoint.userService(oauth2UserService)
 						)
-			//			.successHandler(oauthSuccessHandler)
+						.successHandler(oauthSuccessHandler)
 			);
 		return http.build();
 	}

--- a/src/main/java/com/i6/honterview/controller/OAuthController.java
+++ b/src/main/java/com/i6/honterview/controller/OAuthController.java
@@ -1,0 +1,13 @@
+package com.i6.honterview.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class OAuthController {// TODO : 프론트엔드 연동 후 제거
+
+	@GetMapping("/login")
+	public String login() {
+		return "login";
+	}
+}

--- a/src/main/java/com/i6/honterview/domain/Member.java
+++ b/src/main/java/com/i6/honterview/domain/Member.java
@@ -56,8 +56,9 @@ public class Member {
 	// TODO : status
 
 	@Builder
-	public Member(String email, Provider provider, Role role) {
+	public Member(String email, String nickname, Provider provider, Role role) {
 		this.email = email;
+		this.nickname = nickname;
 		this.provider = provider;
 		this.role = role;
 	}

--- a/src/main/java/com/i6/honterview/domain/Member.java
+++ b/src/main/java/com/i6/honterview/domain/Member.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,8 +32,8 @@ public class Member {
 	@Column(name = "email", nullable = false)
 	private String email;
 
-	@Column(name = "name", nullable = false)
-	private String name;
+	@Column(name = "nickname")
+	private String nickname;
 
 	@Column(name = "birth_date")
 	private String birthDate;
@@ -54,4 +55,10 @@ public class Member {
 
 	// TODO : status
 
+	@Builder
+	public Member(String email, Provider provider, Role role) {
+		this.email = email;
+		this.provider = provider;
+		this.role = role;
+	}
 }

--- a/src/main/java/com/i6/honterview/domain/enums/Provider.java
+++ b/src/main/java/com/i6/honterview/domain/enums/Provider.java
@@ -1,5 +1,14 @@
 package com.i6.honterview.domain.enums;
 
+import java.util.Arrays;
+
 public enum Provider {
 	KAKAO, NAVER, GITHUB;
+
+	public static Provider getProviderFromString(String input) {
+		return Arrays.stream(Provider.values())
+			.filter(provider -> provider.name().equalsIgnoreCase(input))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("No matching enum constant for input: " + input));
+	}
 }

--- a/src/main/java/com/i6/honterview/repository/MemberRepository.java
+++ b/src/main/java/com/i6/honterview/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.i6.honterview.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.i6.honterview.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/i6/honterview/security/auth/OAuth2UserImpl.java
+++ b/src/main/java/com/i6/honterview/security/auth/OAuth2UserImpl.java
@@ -1,0 +1,23 @@
+package com.i6.honterview.security.auth;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import com.i6.honterview.domain.Member;
+
+import lombok.Getter;
+
+@Getter
+public class OAuth2UserImpl extends DefaultOAuth2User {
+
+	private final Member member;
+
+	public OAuth2UserImpl(Collection<? extends GrantedAuthority> authorities,
+		Map<String, Object> attributes, String nameAttributeKey, Member member) {
+		super(authorities, attributes, nameAttributeKey);
+		this.member = member;
+	}
+}

--- a/src/main/java/com/i6/honterview/security/auth/OAuthAttributes.java
+++ b/src/main/java/com/i6/honterview/security/auth/OAuthAttributes.java
@@ -1,0 +1,58 @@
+package com.i6.honterview.security.auth;
+
+import java.util.Map;
+
+import com.i6.honterview.domain.Member;
+import com.i6.honterview.domain.enums.Provider;
+import com.i6.honterview.domain.enums.Role;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OAuthAttributes {
+
+	private Map<String, Object> attributes;
+	private String nameAttributeKey;
+	private String email;
+	private Provider provider;
+	private String name;
+
+	public static OAuthAttributes of(String registrationId, String userNameAttributeName,
+		Map<String, Object> attributes) {
+		Provider provider = Provider.getProviderFromString(registrationId);
+		return ofProviderType(provider, userNameAttributeName, attributes);
+	}
+
+	private static OAuthAttributes ofProviderType(Provider provider, String userNameAttributeName,
+		Map<String, Object> attributes) {
+		return switch (provider) {
+			case KAKAO -> ofKakao(userNameAttributeName, attributes);
+			default -> throw new IllegalArgumentException("지원되지 않는 프로바이더 타입: " + provider);
+		};
+	}
+
+	private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+		Map<String, Object> response = (Map<String, Object>)attributes.get("kakao_account");
+		return buildCommonAttributes(Provider.KAKAO, userNameAttributeName, response);
+	}
+
+	private static OAuthAttributes buildCommonAttributes(Provider provider, String userNameAttributeName,
+		Map<String, Object> attributes) {
+		return OAuthAttributes.builder()
+			.email((String)attributes.get("email"))
+			.attributes(attributes)
+			.provider(provider)
+			.nameAttributeKey(userNameAttributeName)
+			.build();
+	}
+
+	public Member toEntity() {
+		return Member.builder()
+			.provider(provider)
+			.email(email)
+			.role(Role.ROLE_USER)
+			.build();
+	}
+}

--- a/src/main/java/com/i6/honterview/security/auth/OAuthAttributes.java
+++ b/src/main/java/com/i6/honterview/security/auth/OAuthAttributes.java
@@ -1,5 +1,6 @@
 package com.i6.honterview.security.auth;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.i6.honterview.domain.Member;
@@ -14,7 +15,7 @@ import lombok.Getter;
 public class OAuthAttributes {
 
 	private Map<String, Object> attributes;
-	private String nameAttributeKey; // 사용자 속성의 키 값
+	private String attributeKey; // 사용자 속성의 키 값
 	private String email;
 	private Provider provider;
 	private String name;
@@ -47,11 +48,20 @@ public class OAuthAttributes {
 			.email((String)attributes.get("email"))
 			.attributes(attributes)
 			.provider(provider)
-			.nameAttributeKey(userNameAttributeName)
+			.attributeKey(userNameAttributeName)
 			.build();
 	}
 
-	public Member toEntity() {
+	public Map<String, Object> convertToMap() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("id", attributeKey);
+		map.put("key", attributeKey);
+		map.put("email", email);
+		map.put("provider", provider);
+		return map;
+	}
+
+	public Member toMemberEntity() {
 		return Member.builder()
 			.provider(provider)
 			.nickname(name)

--- a/src/main/java/com/i6/honterview/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/i6/honterview/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,64 @@
+package com.i6.honterview.security.jwt;
+
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+	@Value("${jwt.secret-key}")
+	private String secretKey;
+
+	@Value("${jwt.access-expiry-seconds}")
+	private int accessExpirySeconds;
+
+	@Value("${jwt.refresh-expiry-seconds}")
+	private int refreshExpirySeconds;
+
+	public String generateAccessToken(String email, String role) {
+		Date now = new Date();
+		Map<String, String> claim = generateClaim(email, role);
+
+		return Jwts.builder()
+			.issuedAt(now)
+			.expiration(new Date(System.currentTimeMillis() + accessExpirySeconds))
+			.claims(claim)
+			.subject(email)
+			.signWith(getSignInKey())
+			.compact();
+	}
+
+	public String generateRefreshToken(String email, String role) {
+		Date now = new Date();
+		Map<String, String> claim = generateClaim(email, role);
+		return Jwts.builder()
+			.issuedAt(now)
+			.expiration(new Date(System.currentTimeMillis() + refreshExpirySeconds))
+			.claims(claim)
+			.subject(email)
+			.signWith(getSignInKey())
+			.compact();
+	}
+
+	private static Map<String, String> generateClaim(String email, String role) {
+		return Map.of(
+			"email", email,
+			"role", role
+		);
+	}
+
+	private SecretKey getSignInKey() {
+		return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+	}
+}

--- a/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -3,6 +3,7 @@ package com.i6.honterview.security.service;
 import java.io.IOException;
 import java.util.Map;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
 import com.i6.honterview.domain.Member;
 import com.i6.honterview.security.auth.OAuth2UserImpl;
 import com.i6.honterview.security.jwt.JwtTokenProvider;
+import com.i6.honterview.util.HttpResponseUtil;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,12 +34,13 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 		String accessToken = jwtTokenProvider.generateAccessToken(member.getEmail(), member.getRole().name());
 		String refreshToken = jwtTokenProvider.generateRefreshToken(member.getEmail(), member.getRole().name());
 
+		// TODO : refresh token redis에 저장
+
 		Map<String, Object> body = Map.of(
 			"accessToken", accessToken,
 			"refreshToken", refreshToken
 		);
 
-		System.out.println("atk" + accessToken);
-		System.out.println(refreshToken);
+		HttpResponseUtil.setSuccessResponse(response, HttpStatus.OK, body);
 	}
 }

--- a/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,43 @@
+package com.i6.honterview.security.service;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.i6.honterview.domain.Member;
+import com.i6.honterview.security.auth.OAuth2UserImpl;
+import com.i6.honterview.security.jwt.JwtTokenProvider;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+
+		OAuth2UserImpl oAuth2User = (OAuth2UserImpl)authentication.getPrincipal();
+		Member member = oAuth2User.getMember();
+
+		String accessToken = jwtTokenProvider.generateAccessToken(member.getEmail(), member.getRole().name());
+		String refreshToken = jwtTokenProvider.generateRefreshToken(member.getEmail(), member.getRole().name());
+
+		Map<String, Object> body = Map.of(
+			"accessToken", accessToken,
+			"refreshToken", refreshToken
+		);
+
+		System.out.println("atk" + accessToken);
+		System.out.println(refreshToken);
+	}
+}

--- a/src/main/java/com/i6/honterview/security/service/Oauth2UserService.java
+++ b/src/main/java/com/i6/honterview/security/service/Oauth2UserService.java
@@ -1,0 +1,60 @@
+package com.i6.honterview.security.service;
+
+import java.util.Collections;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.i6.honterview.domain.Member;
+import com.i6.honterview.repository.MemberRepository;
+import com.i6.honterview.security.auth.OAuth2UserImpl;
+import com.i6.honterview.security.auth.OAuthAttributes;
+
+import lombok.RequiredArgsConstructor;
+
+// 소셜로부터 받은 userReqeust에 대한 후처리
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class Oauth2UserService extends DefaultOAuth2UserService {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oauth2User = super.loadUser(userRequest);
+
+		// 공급자(Google, Naver, ...) ID
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+		// nameAttributeKey (식별자)
+		String userNameAttributeName = userRequest.getClientRegistration()
+			.getProviderDetails()
+			.getUserInfoEndpoint()
+			.getUserNameAttributeName();
+
+		OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName,
+			oauth2User.getAttributes());
+
+		Member member = saveOrUpdate(attributes);
+
+		return new OAuth2UserImpl(
+			Collections.singleton(new SimpleGrantedAuthority(member.getRole().name())),
+			oauth2User.getAttributes(),
+			attributes.getNameAttributeKey(),
+			member);
+	}
+
+	private Member saveOrUpdate(OAuthAttributes attributes) {
+		return memberRepository.findByEmail(attributes.getEmail())
+			.orElseGet(() -> {
+				Member newMember = attributes.toEntity();
+				return memberRepository.save(newMember);
+			});
+	}
+}

--- a/src/main/java/com/i6/honterview/util/HttpResponseUtil.java
+++ b/src/main/java/com/i6/honterview/util/HttpResponseUtil.java
@@ -1,0 +1,33 @@
+package com.i6.honterview.util;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.i6.honterview.response.ApiResponse;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public class HttpResponseUtil {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	public static void setSuccessResponse(HttpServletResponse response, HttpStatus httpStatus, Object body)
+		throws IOException {
+		String responseBody = objectMapper.writeValueAsString(ApiResponse.ok(body));
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setStatus(httpStatus.value());
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter().write(responseBody);
+	}
+
+	public static void setErrorResponse(HttpServletResponse response, HttpStatus httpStatus, Object body)
+		throws IOException {
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setStatus(httpStatus.value());
+		response.setCharacterEncoding("UTF-8");
+		objectMapper.writeValue(response.getOutputStream(), body);
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,6 +34,10 @@ spring:
             scope:
               - account_email
               - profile_nickname
+jwt:
+  secret-key: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
+  access-expiry-seconds: 120000 # 5min
+  refresh-expiry-seconds: 86400000 #1 day
 
 logging:
   level:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,27 @@ spring:
     hibernate:
       ddl-auto: create-drop
 
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+        registration:
+          kakao:
+            client-id: kakao_client_id
+            client-secret: kakao_client_secret
+            client-authentication-method: client_secret_post
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-name: kakao
+            scope:
+              - account_email
+              - profile_nickname
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <a href="/oauth2/authorization/kakao">카카오 로그인</a>
+</body>
+</html>


### PR DESCRIPTION
## 구현 기능
+ 카카오 로그인 연동 GET /login(해당 페이지에서 로그인 테스트 가능)
+ 로그인 후 토큰 생성 
+ member name -> nickname으로 변환

## 코멘트
아직 보완할 부분이 많은데, pr단위가 너무 커질 것 같아서 다음 pr때 아래 부분 보완하겠습니다! 
- [ ] jwt 필터 적용
- [ ] securityconfig파일 정리
- [ ] 최초 로그인 회원의 경우 회원가입 페이지로 redirect
코드에 설명 추가하겠습니다

resolve: #4 
