### PR TITLE
refactor: 회원 로그인 토큰 처리 방식&jwt 생성 방식 수정

### DIFF
--- a/src/main/java/com/i6/honterview/config/WebSecurityConfig.java
+++ b/src/main/java/com/i6/honterview/config/WebSecurityConfig.java
@@ -74,6 +74,7 @@ public class WebSecurityConfig {
 			antMatcher("/swagger-resources/**"),
 			antMatcher("/v3/api-docs/**"),
 			antMatcher("/webjars/**"),
+			antMatcher("/favicon.ico"),
 
 			// H2-CONSOLE
 			antMatcher("/h2-console/**")

--- a/src/main/java/com/i6/honterview/domain/redis/RefreshToken.java
+++ b/src/main/java/com/i6/honterview/domain/redis/RefreshToken.java
@@ -13,5 +13,4 @@ public class RefreshToken {
 	@Id
 	private String refreshToken;
 	private String accessToken;
-	private String email;
 }

--- a/src/main/java/com/i6/honterview/repository/MemberRepository.java
+++ b/src/main/java/com/i6/honterview/repository/MemberRepository.java
@@ -5,7 +5,8 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.i6.honterview.domain.Member;
+import com.i6.honterview.domain.enums.Provider;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByEmail(String email);
+	Optional<Member> findByEmailAndProvider(String email, Provider provider);
 }

--- a/src/main/java/com/i6/honterview/security/auth/UserDetailsImpl.java
+++ b/src/main/java/com/i6/honterview/security/auth/UserDetailsImpl.java
@@ -16,14 +16,12 @@ import lombok.Getter;
 @Getter
 public class UserDetailsImpl implements UserDetails {
 	private Long id;
-	private String email;
 	private Provider provider;
 	private Collection<? extends GrantedAuthority> authorities;
 
 	@Builder
-	public UserDetailsImpl(Long id, String email, Collection<? extends GrantedAuthority> authorities, Provider provider) {
+	public UserDetailsImpl(Long id, Collection<? extends GrantedAuthority> authorities, Provider provider) {
 		this.id = id;
-		this.email = email;
 		this.authorities = authorities;
 		this.provider = provider;
 	}
@@ -34,7 +32,6 @@ public class UserDetailsImpl implements UserDetails {
 			: null;
 		return new UserDetailsImpl(
 			member.getId(),
-			member.getEmail(),
 			authorities,
 			member.getProvider()
 		);
@@ -52,7 +49,7 @@ public class UserDetailsImpl implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return email;
+		return id.toString();
 	}
 
 	@Override

--- a/src/main/java/com/i6/honterview/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/i6/honterview/security/jwt/JwtAuthenticationEntryPoint.java
@@ -27,15 +27,15 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 		AuthenticationException authException) throws IOException, ServletException {
 		if (authException instanceof CredentialsExpiredException) {
 			// 토큰이 만료된 경우
-			log.warn("Token has expired");
+			log.warn("Token has expired : " + authException.getMessage());
 			HttpResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "토큰의 유효기간이 만료되었습니다.");
 		} else if (authException instanceof BadCredentialsException) {
 			// 토큰이 없거나 인증에 실패한 경우
-			log.warn("Unauthorized");
+			log.warn("Unauthorized : " + authException.getMessage());
 			HttpResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
 		} else {
 			// 다른 인증 오류의 경우
-			log.warn("Unauthorized");
+			log.warn("Unauthorized : " + authException.getMessage());
 			HttpResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "인증 오류가 발생했습니다");
 		}
 	}

--- a/src/main/java/com/i6/honterview/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/i6/honterview/security/jwt/JwtTokenProvider.java
@@ -53,7 +53,6 @@ public class JwtTokenProvider {
 				.collect(Collectors.joining(","));
 		}
 		return Jwts.builder()
-			.claim("id", userDetails.getId())
 			.issuedAt(now)
 			.expiration(new Date(System.currentTimeMillis() + expiryMilliseconds))
 			.subject(userDetails.getUsername())
@@ -75,8 +74,7 @@ public class JwtTokenProvider {
 		}
 
 		UserDetailsImpl principal = UserDetailsImpl.builder()
-			.id(claims.get("id", Long.class))
-			.email(claims.getSubject())
+			.id(Long.parseLong(claims.getSubject()))
 			.authorities(authorities)
 			.build();
 		return new UsernamePasswordAuthenticationToken(principal, accessToken, authorities);
@@ -95,6 +93,11 @@ public class JwtTokenProvider {
 			.verifyWith(getSignInKey())
 			.build()
 			.parse(token);
+	}
+
+	public Long getMemberId(String token) {
+		return Long.parseLong(verifyAndExtractClaims(token)
+			.getSubject());
 	}
 
 	private SecretKey getSignInKey() {

--- a/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -47,7 +47,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		Map<String, Object> body = new HashMap<>();
 		body.put(CHECKING_EXIST_KEY, true);
 
-		Member member = memberRepository.findByEmail(email)
+		Member member = memberRepository.findByEmailAndProvider(email, provider)
 			.orElseGet(() -> {
 				body.put(CHECKING_EXIST_KEY, false);
 				Member newMember = Member.builder()
@@ -63,7 +63,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 		String accessToken = jwtTokenProvider.generateAccessToken(userDetails);
 		String refreshToken = jwtTokenProvider.generateRefreshToken(userDetails);
-		refreshTokenRepository.save(new RefreshToken(refreshToken, accessToken, userDetails.getEmail()));
+		refreshTokenRepository.save(new RefreshToken(refreshToken, accessToken));
 
 		// TODO: cookie로 토큰 전달
 		// Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);

--- a/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -21,6 +21,7 @@ import com.i6.honterview.security.jwt.JwtTokenProvider;
 import com.i6.honterview.util.HttpResponseUtil;
 
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -65,15 +66,21 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		String refreshToken = jwtTokenProvider.generateRefreshToken(userDetails);
 		refreshTokenRepository.save(new RefreshToken(refreshToken, accessToken));
 
-		// TODO: cookie로 토큰 전달
-		// Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
-		// refreshTokenCookie.setSecure(true);
-		// refreshTokenCookie.setHttpOnly(true);
-		// refreshTokenCookie.setPath("/");
-		// response.addCookie(refreshTokenCookie);
+		Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
+		accessTokenCookie.setSecure(true);
+		accessTokenCookie.setHttpOnly(true);
+		accessTokenCookie.setPath("/");
+		response.addCookie(accessTokenCookie);
 
-		body.put("accessToken", accessToken);
-		body.put("refreshToken", refreshToken);
+		// TODO: cookie로 토큰 전달
+		Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+		refreshTokenCookie.setSecure(true);
+		refreshTokenCookie.setHttpOnly(true);
+		refreshTokenCookie.setPath("/");
+		response.addCookie(refreshTokenCookie);
+
+		// body.put("accessToken", accessToken);
+		// body.put("refreshToken", refreshToken);
 		HttpResponseUtil.setSuccessResponse(response, HttpStatus.OK, body);
 	}
 }

--- a/src/main/java/com/i6/honterview/service/AuthService.java
+++ b/src/main/java/com/i6/honterview/service/AuthService.java
@@ -29,7 +29,8 @@ public class AuthService {
 		RefreshToken oldRefreshToken = refreshTokenRepository.findById(request.refreshToken())
 			.orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED));
 
-		Member member = memberRepository.findByEmail(oldRefreshToken.getEmail())
+		Long id = jwtTokenProvider.getMemberId(request.refreshToken());
+		Member member = memberRepository.findById(id)
 			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
 		UserDetailsImpl userDetails = UserDetailsImpl.from(member);
@@ -37,7 +38,7 @@ public class AuthService {
 		String refreshToken = jwtTokenProvider.generateRefreshToken(userDetails);
 
 		refreshTokenRepository.delete(oldRefreshToken);
-		refreshTokenRepository.save(new RefreshToken(refreshToken, accessToken, userDetails.getEmail()));
+		refreshTokenRepository.save(new RefreshToken(refreshToken, accessToken));
 		return new TokenResponse(accessToken, refreshToken);
 	}
 }


### PR DESCRIPTION
## 구현 기능
+ 로그인 후 토큰 전송 방식 수정 (body -> cookie)
+ jwt 생성시 subject의 값을 email -> memberId로 수정
+ 로그인 여부 확인시 email&provider 이용하도록 수정

리뷰 부탁드립니다!
resolve: #14 
