### PR TITLE
fix: 질문 createdBy 저장 로직 구현

### DIFF
--- a/src/main/java/com/i6/honterview/controller/QuestionController.java
+++ b/src/main/java/com/i6/honterview/controller/QuestionController.java
@@ -87,14 +87,15 @@ public class QuestionController {// TODO: 회원 연동
 
 	@Operation(summary = "질문 생성")
 	@PostMapping
-	public ResponseEntity<ApiResponse<Long>> createQuestion(	// TODO: 작성자 정보 포함
-		@Valid @RequestBody QuestionCreateRequest request) {
-		Long id = questionService.createQuestion(request).getId();
+	public ResponseEntity<ApiResponse<QuestionResponse>> createQuestion(
+		@Valid @RequestBody QuestionCreateRequest request,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		QuestionResponse question = questionService.createQuestion(request, userDetails.getUsername());
 		URI location = ServletUriComponentsBuilder.fromCurrentRequestUri()
 			.path("/{id}")
-			.buildAndExpand(id)
+			.buildAndExpand(question.id())
 			.toUri();
-		return ResponseEntity.created(location).body(ApiResponse.created(id));
+		return ResponseEntity.created(location).body(ApiResponse.created(question));
 	}
 
 	@Operation(summary = "질문 수정")

--- a/src/main/java/com/i6/honterview/domain/Question.java
+++ b/src/main/java/com/i6/honterview/domain/Question.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -46,6 +47,7 @@ public class Question extends BaseEntity {
 	@Column(name = "created_by", nullable = false)
 	private String createdBy;
 
+	@Builder
 	public Question(String content, Long parentId, List<Category> categories, String createdBy) {
 		this.content = content;
 		this.parentId = parentId;

--- a/src/main/java/com/i6/honterview/dto/request/TailQuestionSaveRequest.java
+++ b/src/main/java/com/i6/honterview/dto/request/TailQuestionSaveRequest.java
@@ -10,20 +10,24 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-@Schema(description = "질문 생성 요청")
-public record QuestionCreateRequest(
+@Schema(description = "꼬리 질문 저장 요청")
+public record TailQuestionSaveRequest(
 	@NotBlank(message = "질문 내용은 필수 항목입니다.")
 	@Size(min = 2, max = 100, message = "질문 내용은 2자 이상 100자 이하로 입력해주세요.")
 	String content,
 
+	@NotNull(message = "부모 ID값은 필수 항목입니다.")
+	Long parentId,
+
 	@NotNull
 	@Size(min = 1, max = 3, message = "카테고리 목록은 1개 이상 3개 이하까지 등록 가능합니다.")
 	List<Long> categoryIds) {
-	public Question toEntity(List<Category> categories, String createdBy) {
+	public Question toEntity(List<Category> categories) {
 		return Question.builder()
 			.content(content)
+			.parentId(parentId)
 			.categories(categories)
-			.createdBy(createdBy)
+			.createdBy("GPT_CREATED")
 			.build();
 	}
 }

--- a/src/main/java/com/i6/honterview/service/InterviewService.java
+++ b/src/main/java/com/i6/honterview/service/InterviewService.java
@@ -12,7 +12,7 @@ import com.i6.honterview.domain.enums.InterviewStatus;
 import com.i6.honterview.dto.request.AnswerCreateRequest;
 import com.i6.honterview.dto.request.InterviewCreateRequest;
 import com.i6.honterview.dto.request.QuestionAnswerCreateRequest;
-import com.i6.honterview.dto.request.QuestionCreateRequest;
+import com.i6.honterview.dto.request.TailQuestionSaveRequest;
 import com.i6.honterview.dto.response.QuestionAnswerCreateResponse;
 import com.i6.honterview.exception.CustomException;
 import com.i6.honterview.exception.ErrorCode;
@@ -89,9 +89,9 @@ public class InterviewService {
 	}
 
 	private Question createQuestion(String questionContent, Question firstQuestion) {
-		QuestionCreateRequest questionCreateRequest = new QuestionCreateRequest(
+		TailQuestionSaveRequest tailQuestionSaveRequest = new TailQuestionSaveRequest(
 			questionContent, firstQuestion.getId(), firstQuestion.getCategoryIds());
-		return questionService.createQuestion(questionCreateRequest);
+		return questionService.saveTailQuestion(tailQuestionSaveRequest);
 	}
 
 	private Question getFirstQuestionFromInterview(Interview interview) {

--- a/src/main/java/com/i6/honterview/service/QuestionService.java
+++ b/src/main/java/com/i6/honterview/service/QuestionService.java
@@ -13,6 +13,7 @@ import com.i6.honterview.domain.Category;
 import com.i6.honterview.domain.Question;
 import com.i6.honterview.dto.request.QuestionCreateRequest;
 import com.i6.honterview.dto.request.QuestionUpdateRequest;
+import com.i6.honterview.dto.request.TailQuestionSaveRequest;
 import com.i6.honterview.dto.response.AnswerResponse;
 import com.i6.honterview.dto.response.PageResponse;
 import com.i6.honterview.dto.response.QuestionDetailResponse;
@@ -71,12 +72,15 @@ public class QuestionService {// TODO: 멤버&관리자 연동
 			.toList();
 	}
 
-	public Question createQuestion(QuestionCreateRequest request) {
+	public QuestionResponse createQuestion(QuestionCreateRequest request, String creator) {
 		List<Category> categories = categoryService.validateAndGetCategories(request.categoryIds());
-
-		String creator = "MEMBER_1"; // TODO: role에 따른 질문 생성자 정보 저장
 		Question question = questionRepository.save(request.toEntity(categories, creator));
-		return question;
+		return QuestionResponse.from(question);
+	}
+
+	public Question saveTailQuestion(TailQuestionSaveRequest request) {
+		List<Category> categories = categoryService.validateAndGetCategories(request.categoryIds());
+		return questionRepository.save(request.toEntity(categories));
 	}
 
 	public void updateQuestion(Long id, QuestionUpdateRequest request) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -53,8 +53,8 @@ INSERT INTO member (email, nickname, provider, role)
 VALUES ('test@gmail.com', 'test', 'KAKAO', 'ROLE_USER');
 
 -- Interview 더미 데이터
-INSERT INTO interview (id, answer_type, question_count, interview_status, member_id)
-VALUES (1, 'TEXT', 3, 'IN_PROGRESS', 1);
+INSERT INTO interview (answer_type, question_count, interview_status, member_id)
+VALUES ('TEXT', 3, 'IN_PROGRESS', 1);
 
 -- InterviewQuestion 더미 데이터
 INSERT INTO interview_question (interview_id, question_id)


### PR DESCRIPTION
## 구현 기능
+ 회원이 질문을 생성할 경우 createdBy = {memberId} (String형) 으로 저장
+ 꼬리질문의 경우 `GPT_CREATED`로 저장
+ 질문 생성시 질문 내용도 함께 반환하도록 수정
+ 첫 질문 생성과 꼬리질문 저장 로직 분리

코드 설명 코멘트로 추가하겠습니다!

resolve: #50 
