### PR TITLE
fix: dev 브랜치 배포

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,8 +2,7 @@ name: Java CD with Gradle
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [ "dev" ]
 
 permissions:
   contents: read
@@ -44,13 +43,6 @@ jobs:
           username: ${{ secrets.DOCKER_ID }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # 태그 추출
-      - name: Extract tag name
-        id: tag
-        run: |
-          TAG_NAME=${GITHUB_REF#refs/tags/}
-          echo "name=${TAG_NAME//\//-}" >> $GITHUB_OUTPUT
-
       # Docker 이미지 빌드 및 푸시
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v2
@@ -58,7 +50,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_ID }}/honterview:${{ steps.tag.outputs.name }}
+          tags: ${{ secrets.DOCKER_ID }}/honterview
 
       # EC2 배포
       - name: Deploy to AWS EC2
@@ -79,14 +71,14 @@ jobs:
           docker network ls | grep honterview || docker network create honterview
           
           # Docker 이미지 업데이트
-          docker pull ${{ secrets.DOCKER_ID }}/honterview:${{ steps.tag.outputs.name }}
+          docker pull ${{ secrets.DOCKER_ID }}/honterview
           
           # Docker 컨테이너 실행
           docker run -d --name honterview \
             --network=honterview \
             -p 8080:8080 \
             -e TZ=Asia/Seoul \
-            ${{ secrets.DOCKER_ID }}/honterview:${{ steps.tag.outputs.name }}
+            ${{ secrets.DOCKER_ID }}/honterview
           
           docker pull redis
 


### PR DESCRIPTION
## 구현 기능
dev 브랜치 기준으로 배포하되, 태그없이 이미지를 빌드하여 기존 이미지는 대체됨 (태그가 쌓이지 않아요)
추후 main 브랜치에 릴리즈 버전을 머지할 때 버전 & 태그 관리가 필요할 것 같습니다-!

resolve: #96 
