### PR TITLE
fix: 배포 환경에서 로그인 후 쿠키값 전송 안되는 문제 해결

### DIFF
--- a/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -66,17 +66,20 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		redisRepository.saveRefreshToken(refreshToken, member.getId());
 
 		Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
-		accessTokenCookie.setSecure(true);
-		accessTokenCookie.setHttpOnly(true);
+		// accessTokenCookie.setSecure(true);
+		// accessTokenCookie.setHttpOnly(true);
 		accessTokenCookie.setPath("/");
+		accessTokenCookie.setDomain("honterview.site");
 		response.addCookie(accessTokenCookie);
 
 		Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
-		refreshTokenCookie.setSecure(true);
-		refreshTokenCookie.setHttpOnly(true);
+		// refreshTokenCookie.setSecure(true);
+		// refreshTokenCookie.setHttpOnly(true);
 		refreshTokenCookie.setPath("/");
+		accessTokenCookie.setDomain("honterview.site");
 		response.addCookie(refreshTokenCookie);
 
+		response.sendRedirect("http://localhost:3000");
 		HttpResponseUtil.setSuccessResponse(response, HttpStatus.OK, body);
 	}
 }

--- a/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/i6/honterview/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -66,17 +66,18 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		redisRepository.saveRefreshToken(refreshToken, member.getId());
 
 		Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
-		// accessTokenCookie.setSecure(true);
-		// accessTokenCookie.setHttpOnly(true);
+		Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+
+		accessTokenCookie.setMaxAge(1800);
 		accessTokenCookie.setPath("/");
+		accessTokenCookie.setHttpOnly(true);
 		accessTokenCookie.setDomain("honterview.site");
 		response.addCookie(accessTokenCookie);
 
-		Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
-		// refreshTokenCookie.setSecure(true);
-		// refreshTokenCookie.setHttpOnly(true);
+		refreshTokenCookie.setMaxAge(604800);
 		refreshTokenCookie.setPath("/");
-		accessTokenCookie.setDomain("honterview.site");
+		refreshTokenCookie.setHttpOnly(true);
+		refreshTokenCookie.setDomain("honterview.site");
 		response.addCookie(refreshTokenCookie);
 
 		response.sendRedirect("http://localhost:3000");


### PR DESCRIPTION
## 구현 기능
+  secure 설정 임의로 해제(https 적용 전까지)
+ 로그인 후 메인페이지로 리다이렉트(임의 주소)
+ 로그아웃 후 쿠키 제거

## 참고사항
+ 로컬에서는 쿠키 설정, 삭제가 잘 되지만 배포환경에서 잘 동작할지는 확신이 없습니다
+ 클라이언트와 소통을 위해선 https 설정이 필수인것같습니다. 그래서 https적용과, 클라이언트 배포, 서브도메인 설정까지 되어야 동작 확인이 가능할것같아요..

resolve: #99 
