### PR TITLE
feat: 영상, 답변 연결

### DIFF
--- a/src/main/java/com/i6/honterview/domain/Answer.java
+++ b/src/main/java/com/i6/honterview/domain/Answer.java
@@ -63,11 +63,12 @@ public class Answer extends BaseEntity {
 	@JoinColumn(name = "video_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 	private Video video;
 
-	public Answer(String content, Question question, Interview interview) {
+	public Answer(String content, Question question, Interview interview, Video video) {
 		this.content = content;
 		this.question = question;
 		this.interview = interview;
 		this.member = interview.getMember();
+		this.video = video;
 	}
 
 	public void addHeart(AnswerHeart heart) {

--- a/src/main/java/com/i6/honterview/domain/Video.java
+++ b/src/main/java/com/i6/honterview/domain/Video.java
@@ -38,4 +38,9 @@ public class Video extends BaseEntity {
 			", processingTime=" + processingTime +
 			'}';
 	}
+
+	public Video changeProcessingTime(Integer processingTime) {
+		this.processingTime = processingTime;
+		return this;
+	}
 }

--- a/src/main/java/com/i6/honterview/dto/request/AnswerCreateRequest.java
+++ b/src/main/java/com/i6/honterview/dto/request/AnswerCreateRequest.java
@@ -3,11 +3,12 @@ package com.i6.honterview.dto.request;
 import com.i6.honterview.domain.Answer;
 import com.i6.honterview.domain.Interview;
 import com.i6.honterview.domain.Question;
+import com.i6.honterview.domain.Video;
 
 public record AnswerCreateRequest(
 	String content
 ) {
-	public Answer toEntity(Question question, Interview interview) {
-		return new Answer(this.content, question, interview);
+	public Answer toEntity(Question question, Interview interview, Video video) {
+		return new Answer(this.content, question, interview, video);
 	}
 }

--- a/src/main/java/com/i6/honterview/dto/request/QuestionAnswerCreateRequest.java
+++ b/src/main/java/com/i6/honterview/dto/request/QuestionAnswerCreateRequest.java
@@ -1,5 +1,7 @@
 package com.i6.honterview.dto.request;
 
+import org.springframework.lang.Nullable;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -14,6 +16,14 @@ public record QuestionAnswerCreateRequest(
 
 	@Schema(description = "답변", example = "조회된 엔티티의 개수만큼 연관된 엔티티를 조회하기 위해 추가적인 쿼리가 발생하는 문제를 의미합니다.")
 	@NotBlank(message = "답변 내용은 필수 항목입니다.")
-	String answerContent
+	String answerContent,
+
+	@Schema(description = "영상 id(화상일 경우에만 존재)", example = "123 (nullable) ")
+	@Nullable
+	Long videoId,
+
+	@Schema(description = "진행시간(초 단위, 화상일 경우에만 존재)", example = "60 (초단위, nullable)")
+	@Nullable
+	Integer processingTime
 ) {
 }

--- a/src/main/java/com/i6/honterview/dto/response/QuestionAndAnswerResponse.java
+++ b/src/main/java/com/i6/honterview/dto/response/QuestionAndAnswerResponse.java
@@ -21,7 +21,11 @@ public record QuestionAndAnswerResponse(
 
 	@Schema(description = "실제 답변 시간(초), null일 경우 반환X", example = "30")
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	Integer processingTime
+	Integer processingTime,
+
+	@Schema(description = "영상 id, null일 경우 반환X", example = "123")
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	Long videoId
 ) {
 	public static QuestionAndAnswerResponse of(Question question, Answer answer, Integer processingTime) {
 		return new QuestionAndAnswerResponse(
@@ -29,7 +33,8 @@ public record QuestionAndAnswerResponse(
 			question.getContent(),
 			answer != null ? answer.getId() : null,
 			answer != null ? answer.getContent() : null,
-			processingTime
+			processingTime,
+			answer != null && answer.getVideo() != null ? answer.getVideo().getId() : null
 		);
 	}
 }

--- a/src/main/java/com/i6/honterview/dto/response/UploadUrlResponse.java
+++ b/src/main/java/com/i6/honterview/dto/response/UploadUrlResponse.java
@@ -1,10 +1,21 @@
 package com.i6.honterview.dto.response;
 
+import com.i6.honterview.domain.Video;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "업로드 URL 응답")
 public record UploadUrlResponse(
+	@Schema(description = "영상 id", example = "123")
+	Long videoId,
+
 	@Schema(description = "업로드 URL", example = "https://honterview-s3-bucket.com")
 	String uploadUrl
 ) {
+	public static UploadUrlResponse of(Video video, String uploadUrl) {
+		return new UploadUrlResponse(
+			video.getId(),
+			uploadUrl
+		);
+	}
 }

--- a/src/main/java/com/i6/honterview/service/AnswerService.java
+++ b/src/main/java/com/i6/honterview/service/AnswerService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.i6.honterview.domain.Answer;
 import com.i6.honterview.domain.Interview;
 import com.i6.honterview.domain.Question;
+import com.i6.honterview.domain.Video;
 import com.i6.honterview.dto.request.AnswerCreateRequest;
 import com.i6.honterview.exception.CustomException;
 import com.i6.honterview.exception.ErrorCode;
@@ -20,11 +21,11 @@ public class AnswerService {
 
 	private final AnswerRepository answerRepository;
 
-	public Answer createAnswer(AnswerCreateRequest request, Question question, Interview interview) {
+	public Answer createAnswer(AnswerCreateRequest request, Question question, Interview interview, Video video) {
 		boolean answerExists = answerRepository.existsByInterviewAndQuestion(interview, question);
 		if (answerExists) {
 			throw new CustomException(ErrorCode.ANSWER_DUPLICATED);
 		}
-		return answerRepository.save(request.toEntity(question, interview));
+		return answerRepository.save(request.toEntity(question, interview, video));
 	}
 }

--- a/src/main/java/com/i6/honterview/service/FileService.java
+++ b/src/main/java/com/i6/honterview/service/FileService.java
@@ -46,8 +46,8 @@ public class FileService {
 		String fileName = FileUtils.generateFileName();
 		try {
 			URL url = s3Template.createSignedPutURL(s3Bucket, fileName, Duration.ofMinutes(10));
-			videoRepository.save(new Video(fileName)); // TODO: answer과 연관지어야 함
-			return new UploadUrlResponse(url.toString());
+			Video video = videoRepository.save(new Video(fileName));
+			return UploadUrlResponse.of(video, url.toString());
 		} catch (S3Exception e) {
 			log.error("createSignedPutURL failed : ", e);
 			throw new CustomException(ErrorCode.GENERATE_UPLOAD_URL_FAILED);

--- a/src/main/java/com/i6/honterview/util/FileUtils.java
+++ b/src/main/java/com/i6/honterview/util/FileUtils.java
@@ -6,7 +6,7 @@ import java.time.format.DateTimeFormatter;
 public class FileUtils {
 
 	private static final String FILENAME_PREFIX = "honterview_";
-	private static final String FILE_EXTENSTION = ".mp4"; // TODO 프론트랑 파일 확장자 정하기
+	private static final String FILE_EXTENSTION = ".webm";
 
 	private FileUtils() {
 	}

--- a/src/main/java/com/i6/honterview/util/FileUtils.java
+++ b/src/main/java/com/i6/honterview/util/FileUtils.java
@@ -14,7 +14,7 @@ public class FileUtils {
 	/**
 	 * 유니크한 파일 이름을 생성합니다
 	 *
-	 * @return ex) honterview_202403040929137878.mp4
+	 * @return ex) honterview_202403040929137878.webm
 	 */
 
 	public static String generateFileName() {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS answer_heart
 CREATE TABLE IF NOT EXISTS video
 (
     id              BIGINT PRIMARY KEY AUTO_INCREMENT,
-    file_name       VARCHAR(10) NOT NULL,
+    file_name       VARCHAR(50) NOT NULL,
     processing_time INT         NOT NULL,
     created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP


### PR DESCRIPTION
## 요약
영상 videoId와 answer을 연결합니다.

## 기능 상세
- [x] 면접/답변 저장할 때 videoId와 processingTime 추가 (POST /api/v1/interviews/{id})
- [x] 면접 현황조회 API에서 답변별로 videoId 추가 (POST /api/v1/interviews/{id})
- [x] 파일 업로드 URL 조회시 videoId 추가 (GET /api/v1/files/upload-url/{interviewId})

resolve: #98 
