### PR TITLE
fix: 면접 현황 조회시 상태값 추가

### DIFF
--- a/src/main/java/com/i6/honterview/dto/response/InterviewInfoResponse.java
+++ b/src/main/java/com/i6/honterview/dto/response/InterviewInfoResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.i6.honterview.domain.Interview;
 import com.i6.honterview.domain.enums.AnswerType;
+import com.i6.honterview.domain.enums.InterviewStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -22,6 +23,9 @@ public record InterviewInfoResponse(
 	@Schema(description = "해당 면접의 총 질문 개수", example = "3")
 	int questionCount,
 
+	@Schema(description = "진행 상태", example = "IN_PROGRESS/COMPLETED")
+	InterviewStatus status,
+
 	@Schema(description = "해당 면접의 질문&답변 목록")
 	List<QuestionAndAnswerResponse> questionsAndAnswers,
 
@@ -35,6 +39,7 @@ public record InterviewInfoResponse(
 			interview.getTimer(),
 			interview.getAnswerType(),
 			interview.getQuestionCount(),
+			interview.getStatus(),
 			questionsAndAnswers,
 			interview.findFirstQuestion().getCategoryNames()
 		);


### PR DESCRIPTION
## 구현 기능
면접 현황 조회시 status 응답을 추가하였습니다.
(면접 현황이 COMPLETED 일 경우 면접 진행 페이지에서 튕기도록 프론트 수정)

resolve: #113 
