### PR TITLE
fix: 현재 로그인한 사용자가 인터뷰의 주인인지 확인하는 validation 추가

### DIFF
--- a/src/main/java/com/i6/honterview/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/i6/honterview/domain/interview/controller/InterviewController.java
@@ -54,8 +54,10 @@ public class InterviewController {
 	@Operation(summary = "면접 상태 수정(면접 완료)")
 	@PatchMapping("/{id}")
 	public ResponseEntity<Void> updateInterviewStatus(
-		@Parameter(description = "면접 id", example = "123") @PathVariable Long id) {
-		interviewService.updateInterviewStatus(id);
+		@Parameter(description = "면접 id", example = "123") @PathVariable Long id,
+		@CurrentAccount Long memberId
+	) {
+		interviewService.updateInterviewStatus(id, memberId);
 		return ResponseEntity.noContent().build();
 	}
 
@@ -81,20 +83,22 @@ public class InterviewController {
 
 	@Operation(summary = "답변 공개여부 수정(면접 결과)")
 	@PatchMapping("/{id}/visibility")
-	public ResponseEntity<ApiResponse<AnswersVisibilityUpdateResponse>> changeAnswersVisibility(// TODO: 멤버 연동
+	public ResponseEntity<ApiResponse<AnswersVisibilityUpdateResponse>> changeAnswersVisibility(
 		@Parameter(description = "면접 id", example = "123") @PathVariable Long id,
-		@RequestBody List<AnswerVisibilityUpdateRequest> request
+		@RequestBody List<AnswerVisibilityUpdateRequest> request,
+		@CurrentAccount Long memberId
 	) {
-		AnswersVisibilityUpdateResponse response = interviewService.changeAnswersVisibility(id, request);
+		AnswersVisibilityUpdateResponse response = interviewService.changeAnswersVisibility(id, request, memberId);
 		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 
 	@Operation(summary = "면접 현황 조회")
 	@GetMapping("/{id}")
 	public ResponseEntity<ApiResponse<InterviewInfoResponse>> getInterviewInfo(
-		@Parameter(description = "면접 id", example = "123") @PathVariable Long id
+		@Parameter(description = "면접 id", example = "123") @PathVariable Long id,
+		@CurrentAccount Long memberId
 	) {
-		InterviewInfoResponse response = interviewService.getInterviewInfo(id);
+		InterviewInfoResponse response = interviewService.getInterviewInfo(id, memberId);
 		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 }

--- a/src/main/java/com/i6/honterview/domain/interview/controller/VideoController.java
+++ b/src/main/java/com/i6/honterview/domain/interview/controller/VideoController.java
@@ -40,9 +40,9 @@ public class VideoController {
 	@GetMapping("/download-url/{videoId}")
 	public ResponseEntity<ApiResponse<DownloadUrlResponse>> getDownloadUrl(
 		@Parameter(description = "영상 id", example = "123") @PathVariable Long videoId,
-		@CurrentAccount Long memberId // TODO:?? 다운로드시 member 비교 로직을 위한걸까요?
+		@CurrentAccount Long memberId
 	) {
-		DownloadUrlResponse response = videoService.generateDownloadUrl(videoId);
+		DownloadUrlResponse response = videoService.generateDownloadUrl(videoId, memberId);
 		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 }

--- a/src/main/java/com/i6/honterview/domain/interview/entity/Interview.java
+++ b/src/main/java/com/i6/honterview/domain/interview/entity/Interview.java
@@ -105,4 +105,10 @@ public class Interview extends BaseEntity {
 	public void addVideo(Video video) {
 		this.video = video;
 	}
+
+	public void validateInterviewee(Long memberId) {
+		if (!isSameInterviewee(memberId)) {
+			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
+		}
+	}
 }

--- a/src/main/java/com/i6/honterview/domain/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/i6/honterview/domain/interview/repository/InterviewRepository.java
@@ -15,4 +15,6 @@ public interface InterviewRepository extends JpaRepository<Interview, Long>, Int
 	Optional<Interview> findByIdWithInterviewQuestions(@Param("interviewId") Long interviewId);
 
 	boolean existsByIdAndStatus(Long id, InterviewStatus status);
+
+	Optional<Interview> findByVideoId(Long videoId);
 }

--- a/src/main/java/com/i6/honterview/domain/interview/service/InterviewService.java
+++ b/src/main/java/com/i6/honterview/domain/interview/service/InterviewService.java
@@ -59,7 +59,7 @@ public class InterviewService {
 	public void updateInterviewStatus(Long interviewId, Long memberId) {
 		Interview interview = interviewRepository.findById(interviewId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
-		validateSameInterviewee(memberId, interview);
+		interview.validateInterviewee(memberId);
 
 		if (interview.getStatus().equals(InterviewStatus.IN_PROGRESS)) {
 			interview.changeStatus(InterviewStatus.COMPLETED);
@@ -69,7 +69,7 @@ public class InterviewService {
 	public void deleteInterview(Long id, Long memberId) {
 		Interview interview = interviewRepository.findByIdWithInterviewQuestions(id)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
-		validateSameInterviewee(memberId, interview);
+		interview.validateInterviewee(memberId);
 
 		if (!interview.isDeletable()) {
 			throw new CustomException(ErrorCode.INTERVIEW_DELETE_FORBIDDEN);
@@ -81,7 +81,7 @@ public class InterviewService {
 		QuestionAnswerCreateRequest request) {
 		Interview interview = interviewRepository.findByIdWithInterviewQuestions(id)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
-		validateSameInterviewee(memberId, interview);
+		interview.validateInterviewee(memberId);
 
 		validateAnswerCount(interview);
 
@@ -101,7 +101,7 @@ public class InterviewService {
 	public InterviewInfoResponse getInterviewInfo(Long interviewId, Long memberId) {
 		Interview interview = interviewRepository.findByIdWithInterviewQuestions(interviewId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
-		validateSameInterviewee(memberId, interview);
+		interview.validateInterviewee(memberId);
 
 		List<QuestionAndAnswerResponse> questionsAndAnswers = createQuestionAndAnswerResponses(interview);
 		return InterviewInfoResponse.of(interview, questionsAndAnswers);
@@ -111,7 +111,7 @@ public class InterviewService {
 		List<AnswerVisibilityUpdateRequest> request, Long memberId) {
 		Interview interview = interviewRepository.findById(interviewId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
-		validateSameInterviewee(memberId, interview);
+		interview.validateInterviewee(memberId);
 
 		List<Answer> answers = answerService.findByInterviewId(interview.getId());
 		Map<Long, Answer> answerMap = answers.stream()
@@ -166,12 +166,6 @@ public class InterviewService {
 				return QuestionAndAnswerResponse.of(question, answer);
 			})
 			.toList();
-	}
-
-	private void validateSameInterviewee(Long memberId, Interview interview) {
-		if (!interview.isSameInterviewee(memberId)) {
-			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
-		}
 	}
 
 	private void validateAnswerCount(Interview interview) {

--- a/src/main/java/com/i6/honterview/domain/interview/service/InterviewService.java
+++ b/src/main/java/com/i6/honterview/domain/interview/service/InterviewService.java
@@ -56,9 +56,11 @@ public class InterviewService {
 		return interview.getId();
 	}
 
-	public void updateInterviewStatus(Long id) {
-		Interview interview = interviewRepository.findById(id)
+	public void updateInterviewStatus(Long interviewId, Long memberId) {
+		Interview interview = interviewRepository.findById(interviewId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
+		validateSameInterviewee(memberId, interview);
+
 		if (interview.getStatus().equals(InterviewStatus.IN_PROGRESS)) {
 			interview.changeStatus(InterviewStatus.COMPLETED);
 		}
@@ -67,10 +69,7 @@ public class InterviewService {
 	public void deleteInterview(Long id, Long memberId) {
 		Interview interview = interviewRepository.findByIdWithInterviewQuestions(id)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
-
-		if (!interview.isSameInterviewee(memberId)) {
-			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
-		}
+		validateSameInterviewee(memberId, interview);
 
 		if (!interview.isDeletable()) {
 			throw new CustomException(ErrorCode.INTERVIEW_DELETE_FORBIDDEN);
@@ -82,10 +81,7 @@ public class InterviewService {
 		QuestionAnswerCreateRequest request) {
 		Interview interview = interviewRepository.findByIdWithInterviewQuestions(id)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
-
-		if (!interview.isSameInterviewee(memberId)) {
-			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
-		}
+		validateSameInterviewee(memberId, interview);
 
 		validateAnswerCount(interview);
 
@@ -102,45 +98,20 @@ public class InterviewService {
 		return QuestionAnswerCreateResponse.of(question, answer);
 	}
 
-	private void validateAnswerCount(Interview interview) {
-		int answerCount = interview.getAnswers().size();
-		if (answerCount >= interview.getQuestionCount()) {
-			throw new CustomException(ErrorCode.TOO_MANY_ANSWERS);
-		}
-	}
-
-	public InterviewInfoResponse getInterviewInfo(Long id) {
-		Interview interview = interviewRepository.findByIdWithInterviewQuestions(id)
+	public InterviewInfoResponse getInterviewInfo(Long interviewId, Long memberId) {
+		Interview interview = interviewRepository.findByIdWithInterviewQuestions(interviewId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
+		validateSameInterviewee(memberId, interview);
+
 		List<QuestionAndAnswerResponse> questionsAndAnswers = createQuestionAndAnswerResponses(interview);
 		return InterviewInfoResponse.of(interview, questionsAndAnswers);
 	}
 
-	private Answer createAnswer(String answerContent, Integer processingTime, Interview interview, Question question) {
-		AnswerCreateRequest answerCreateRequest = new AnswerCreateRequest(answerContent, processingTime);
-		return answerService.createAnswer(answerCreateRequest, question, interview);
-	}
-
-	private Question createQuestion(String questionContent, Question firstQuestion) {
-		TailQuestionSaveRequest tailQuestionSaveRequest = new TailQuestionSaveRequest(
-			questionContent, firstQuestion.getId(), firstQuestion.getCategoryIds());
-		return questionService.saveTailQuestion(tailQuestionSaveRequest);
-	}
-
-	private List<QuestionAndAnswerResponse> createQuestionAndAnswerResponses(Interview interview) {// TODO: N+1 문제 해결
-		return interview.getInterviewQuestions().stream()
-			.map(interviewQuestion -> {
-				Question question = interviewQuestion.getQuestion();
-				Answer answer = answerService.findByInterviewAndQuestion(interview, question).orElse(null);
-				return QuestionAndAnswerResponse.of(question, answer);
-			})
-			.toList();
-	}
-
 	public AnswersVisibilityUpdateResponse changeAnswersVisibility(Long interviewId,
-		List<AnswerVisibilityUpdateRequest> request) {
+		List<AnswerVisibilityUpdateRequest> request, Long memberId) {
 		Interview interview = interviewRepository.findById(interviewId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
+		validateSameInterviewee(memberId, interview);
 
 		List<Answer> answers = answerService.findByInterviewId(interview.getId());
 		Map<Long, Answer> answerMap = answers.stream()
@@ -170,4 +141,44 @@ public class InterviewService {
 	public boolean existsByIdAndStatus(Long interviewId, InterviewStatus status) {
 		return interviewRepository.existsByIdAndStatus(interviewId, status);
 	}
+
+	public Interview findByVideoId(Long videoId) {
+		return interviewRepository.findByVideoId(videoId)
+			.orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_NOT_FOUND));
+	}
+	
+	private Answer createAnswer(String answerContent, Integer processingTime, Interview interview, Question question) {
+		AnswerCreateRequest answerCreateRequest = new AnswerCreateRequest(answerContent, processingTime);
+		return answerService.createAnswer(answerCreateRequest, question, interview);
+	}
+
+	private Question createQuestion(String questionContent, Question firstQuestion) {
+		TailQuestionSaveRequest tailQuestionSaveRequest = new TailQuestionSaveRequest(
+			questionContent, firstQuestion.getId(), firstQuestion.getCategoryIds());
+		return questionService.saveTailQuestion(tailQuestionSaveRequest);
+	}
+
+	private List<QuestionAndAnswerResponse> createQuestionAndAnswerResponses(Interview interview) {// TODO: N+1 문제 해결
+		return interview.getInterviewQuestions().stream()
+			.map(interviewQuestion -> {
+				Question question = interviewQuestion.getQuestion();
+				Answer answer = answerService.findByInterviewAndQuestion(interview, question).orElse(null);
+				return QuestionAndAnswerResponse.of(question, answer);
+			})
+			.toList();
+	}
+
+	private void validateSameInterviewee(Long memberId, Interview interview) {
+		if (!interview.isSameInterviewee(memberId)) {
+			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
+		}
+	}
+
+	private void validateAnswerCount(Interview interview) {
+		int answerCount = interview.getAnswers().size();
+		if (answerCount >= interview.getQuestionCount()) {
+			throw new CustomException(ErrorCode.TOO_MANY_ANSWERS);
+		}
+	}
+
 }

--- a/src/main/java/com/i6/honterview/domain/interview/service/VideoService.java
+++ b/src/main/java/com/i6/honterview/domain/interview/service/VideoService.java
@@ -36,10 +36,7 @@ public class VideoService {
 
 	public UploadUrlResponse generateUploadUrl(Long interviewId, Long memberId) {
 		Interview interview = interviewService.findById(interviewId);
-
-		if (!interview.isSameInterviewee(memberId)) {
-			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
-		}
+		validateSameInterviewee(memberId, interview);
 
 		String fileName = FileNameUtil.generateFileName();
 		try {
@@ -53,8 +50,11 @@ public class VideoService {
 		}
 	}
 
-	public DownloadUrlResponse generateDownloadUrl(Long videoId) {
+	public DownloadUrlResponse generateDownloadUrl(Long videoId, Long memberId) {
 		Video video = findById(videoId);
+		Interview interview = interviewService.findByVideoId(video.getId());
+		validateSameInterviewee(memberId, interview);
+
 		try {
 			URL url = s3Template.createSignedGetURL(s3Bucket, video.getFileName(), Duration.ofMinutes(10));
 			return new DownloadUrlResponse(url.toString());
@@ -68,4 +68,11 @@ public class VideoService {
 		return videoRepository.findById(id)
 			.orElseThrow(() -> new CustomException(ErrorCode.VIDEO_NOT_FOUND));
 	}
+
+	private void validateSameInterviewee(Long memberId, Interview interview) {
+		if (!interview.isSameInterviewee(memberId)) {
+			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
+		}
+	}
+
 }

--- a/src/main/java/com/i6/honterview/domain/interview/service/VideoService.java
+++ b/src/main/java/com/i6/honterview/domain/interview/service/VideoService.java
@@ -36,7 +36,7 @@ public class VideoService {
 
 	public UploadUrlResponse generateUploadUrl(Long interviewId, Long memberId) {
 		Interview interview = interviewService.findById(interviewId);
-		validateSameInterviewee(memberId, interview);
+		interview.validateInterviewee(memberId);
 
 		String fileName = FileNameUtil.generateFileName();
 		try {
@@ -53,7 +53,7 @@ public class VideoService {
 	public DownloadUrlResponse generateDownloadUrl(Long videoId, Long memberId) {
 		Video video = findById(videoId);
 		Interview interview = interviewService.findByVideoId(video.getId());
-		validateSameInterviewee(memberId, interview);
+		interview.validateInterviewee(memberId);
 
 		try {
 			URL url = s3Template.createSignedGetURL(s3Bucket, video.getFileName(), Duration.ofMinutes(10));
@@ -68,11 +68,4 @@ public class VideoService {
 		return videoRepository.findById(id)
 			.orElseThrow(() -> new CustomException(ErrorCode.VIDEO_NOT_FOUND));
 	}
-
-	private void validateSameInterviewee(Long memberId, Interview interview) {
-		if (!interview.isSameInterviewee(memberId)) {
-			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
-		}
-	}
-
 }


### PR DESCRIPTION
## 구현 기능
+ 현재 로그인한 사용자가 해당 면접의 주인인지 확인하는 validation 로직을 추가합니다.
+ 검증 로직이 여러 서비스에서 활용되는 거 같아 도메인 내부에 검증 메소드를 위치시켰는데 어떤가요?!

Interview.java
```java
	public void validateInterviewee(Long memberId) {
		if (!isSameInterviewee(memberId)) {
			throw new CustomException(ErrorCode.INTERVIEWEE_NOT_SAME);
		}
	}
```


resolve: #139 
