### PR TITLE
fix: 질문 상세 조회 api 권한설정 수정 

### DIFF
--- a/src/main/java/com/i6/honterview/config/WebSecurityConfig.java
+++ b/src/main/java/com/i6/honterview/config/WebSecurityConfig.java
@@ -73,7 +73,9 @@ public class WebSecurityConfig {
 			antMatcher("/api/*/auth/admin/**"),
 
 			// question
-			antMatcher(GET, "/api/*/questions/**"),
+			antMatcher(GET, "/api/*/questions"),
+			antMatcher(GET, "/api/*/questions/by-category"),
+			antMatcher(GET, "/api/*/questions/*/random"),
 			antMatcher("/api/*/categories"),
 
 			// DOCS
@@ -164,8 +166,8 @@ public class WebSecurityConfig {
 	public SecurityFilterChain securityFilterChainDefault(HttpSecurity http) throws Exception {
 		configureCommonSecuritySettings(http);
 		http.authorizeHttpRequests(authorize -> authorize
-				.anyRequest()
-				.authenticated()
+				.requestMatchers(GET, "/api/v1/questions/**").permitAll()
+				.anyRequest().authenticated()
 			)
 			.addFilterAfter(new JwtAuthenticationFilter(jwtTokenProvider), ExceptionTranslationFilter.class)
 			.exceptionHandling(exception -> {


### PR DESCRIPTION
## 구현 기능
- 질문 상세 조회(GET /questions/{id})에서 로그인한 사용자의 정보가 필요합니다. (로그인한 사용자의 북마크/좋아요 여부를 판단해야 함) 
- JwtAuthenticationFilter를 적용하여 setAuthentication 설정을 해야하는 대신, 로그인하지 않은 사용자도 접근 가능해야 하므로 permitAll 권한이 필요합니다.

이외 아래 3개는 기존 권한(permitAll)을 그대로 유지합니다.
- 질문 목록 조회 GET /questions
- 꼬리질문 3개 랜덤 조회 GET /questions/{id}/random
- 카테고리 이름에 의한 질문 전체 조회 GET /questions/by-category

resolve: #141 
