### PR TITLE
fix: 토큰 재발급 쿠키 값 세팅하는 방법으로 변경 

### DIFF
--- a/src/main/java/com/i6/honterview/common/util/CookieUtil.java
+++ b/src/main/java/com/i6/honterview/common/util/CookieUtil.java
@@ -23,7 +23,7 @@ public class CookieUtil {
 	}
 
 	public static void removeCookie(String name, HttpServletResponse response) {
-		ResponseCookie cookie = ResponseCookie.from(name, null)
+		ResponseCookie cookie = ResponseCookie.from(name, "")
 			.maxAge(0)
 			.path("/")
 			.secure(true)


### PR DESCRIPTION
## 구현 기능
+  토큰 재발급시 토큰을 body -> Set-Cookie로 전달하도록 변경
+ 쿠키 제거 로직 ResponseCookie.from(name, null) -> ResponseCookie.from(name, "")로 변경

resolve: #149 
