### PR TITLE
refactor: 질문 키워드 검색 성능 개선

### DIFF
--- a/src/main/java/com/i6/honterview/common/contributor/MatchFunctionContributor.java
+++ b/src/main/java/com/i6/honterview/common/contributor/MatchFunctionContributor.java
@@ -1,0 +1,17 @@
+package com.i6.honterview.common.contributor;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MatchFunctionContributor implements FunctionContributor {
+	private static final String FUNCTION_NAME = "match_against";
+	private static final String FUNCTION_PATTERN = "match(?1) against (?2 in boolean mode)";
+
+	@Override
+	public void contributeFunctions(final FunctionContributions functionContributions) {
+		functionContributions.getFunctionRegistry()
+			.registerPattern(FUNCTION_NAME, FUNCTION_PATTERN,
+				functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.DOUBLE));
+	}
+}

--- a/src/main/java/com/i6/honterview/domain/question/repository/QuestionQueryDslRepository.java
+++ b/src/main/java/com/i6/honterview/domain/question/repository/QuestionQueryDslRepository.java
@@ -6,11 +6,11 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.i6.honterview.domain.question.dto.request.QuestionPageRequest;
 import com.i6.honterview.domain.question.entity.Question;
 
 public interface QuestionQueryDslRepository {
-	Page<Question> findQuestionsByKeywordAndCategoryNamesWithPage(Pageable pageable, String query,
-		List<String> categoryNames, String orderType);
+	Page<Question> findQuestionsByKeywordAndCategoryNamesWithPage(QuestionPageRequest request);
 
 	List<Question> findQuestionsByCategoryNames(List<String> categoryNames);
 

--- a/src/main/java/com/i6/honterview/domain/question/repository/QuestionQueryDslRepositoryImpl.java
+++ b/src/main/java/com/i6/honterview/domain/question/repository/QuestionQueryDslRepositoryImpl.java
@@ -19,6 +19,7 @@ import org.springframework.util.StringUtils;
 
 import com.i6.honterview.common.exception.CustomException;
 import com.i6.honterview.common.exception.ErrorCode;
+import com.i6.honterview.domain.question.dto.request.QuestionPageRequest;
 import com.i6.honterview.domain.question.entity.Question;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -34,16 +35,16 @@ public class QuestionQueryDslRepositoryImpl implements QuestionQueryDslRepositor
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Page<Question> findQuestionsByKeywordAndCategoryNamesWithPage(Pageable pageable, String query,
-		List<String> categoryNames, String orderType) {
+	public Page<Question> findQuestionsByKeywordAndCategoryNamesWithPage(QuestionPageRequest request) {
+		Pageable pageable = request.getPageable();
 		// 조건 생성 - 카테고리 ID 조회 조건, 검색 조건 및 결합
-		BooleanExpression categoryCondition = createCategoryCondition(categoryNames);
-		BooleanExpression searchCondition = createSearchCondition(query);
+		BooleanExpression categoryCondition = createCategoryCondition(request.getCategoryNames());
+		BooleanExpression searchCondition = createSearchCondition(request.getQuery());
 		BooleanExpression combinedCondition =
 			searchCondition != null ? searchCondition.and(categoryCondition) : categoryCondition;
 
 		// 질문 조회
-		List<Question> questions = fetchQuestions(pageable, combinedCondition, orderType);
+		List<Question> questions = fetchQuestions(pageable, combinedCondition, request.getOrderType());
 
 		// 카운트 쿼리
 		JPAQuery<Long> countQuery = fetchQuestionCount(combinedCondition);

--- a/src/main/java/com/i6/honterview/domain/question/service/QuestionService.java
+++ b/src/main/java/com/i6/honterview/domain/question/service/QuestionService.java
@@ -46,13 +46,8 @@ public class QuestionService {// TODO: 멤버&관리자 연동
 
 	@Transactional(readOnly = true)
 	public PageResponse<QuestionWithCategoriesResponse> getQuestions(QuestionPageRequest request) {
-		Pageable pageable = request.getPageable();
 		Page<Question> questions = questionRepository.
-			findQuestionsByKeywordAndCategoryNamesWithPage(
-				pageable,
-				request.getQuery(),
-				request.getCategoryNames(),
-				request.getOrderType());
+			findQuestionsByKeywordAndCategoryNamesWithPage(request);
 		return PageResponse.of(questions, QuestionWithCategoriesResponse::from);
 	}
 

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.i6.honterview.common.contributor.MatchFunctionContributor

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -52,7 +52,8 @@ CREATE TABLE IF NOT EXISTS category
     id            BIGINT PRIMARY KEY AUTO_INCREMENT,
     category_name VARCHAR(20) NOT NULL,
     created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    updated_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE INDEX category_unique_idx_name (category_name)
 );
 
 CREATE TABLE IF NOT EXISTS question
@@ -63,7 +64,9 @@ CREATE TABLE IF NOT EXISTS question
     hearts_count BIGINT      NOT NULL DEFAULT 0,
     created_by   VARCHAR(20) NOT NULL,
     created_at   TIMESTAMP            DEFAULT CURRENT_TIMESTAMP,
-    updated_at   TIMESTAMP            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    updated_at   TIMESTAMP            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX question_idx_content (content),
+    FULLTEXT INDEX question_fulltext_idx_content (content) WITH PARSER ngram
 );
 
 CREATE TABLE IF NOT EXISTS question_category


### PR DESCRIPTION
## 구현 기능
+ fulltext index를 적용해 질문 키워드 검색 성능을 개선했습니다.
+ 테스트는 AOP를 사용했습니다. 테스트용 코드를 프로덕션에 올릴 필요는 없을 것 같아서 추가 안했습니다. 노션 문서로 남겨놓을게요!

적용 전(like 쿼리)
![스크린샷 2024-04-03 101735](https://github.com/DevCourse-I6/Team-I6-Honterview-BE/assets/77001047/ac2146b3-041d-4d6c-a4eb-a81b07cedf6f)


적용 후(fulltext index)
![스크린샷 2024-04-03 102531](https://github.com/DevCourse-I6/Team-I6-Honterview-BE/assets/77001047/ea520314-e5e2-4020-9dfe-8b52db91bff0)

결과 화면(조회 검색어를 'spt'로 함)
![스크린샷 2024-04-03 105112](https://github.com/DevCourse-I6/Team-I6-Honterview-BE/assets/77001047/36694ac1-9b47-49fd-9b4e-806d54f1262e)

<details>
<summary>테스트 데이터</summary>
Docker로 MySQL 띄운 후 아래 쿼리로 10만건의 데이터 삽입. </br>
question.content에 "Question <랜덤알파벳3자> Question" 형태의 데이터가 삽입됨

```sql
def greet():
    print("Hello, world!")

greet()
```
</details>


## 참고
+ rds에 index 생성 후 실행해야 오류 발생 안합니다!
+ 검색 조건이 아얘 없을 땐 실행 속도가 현저히 느립니다. category에도 인덱스를 생성하면 조금 개선되긴 합니다만, 추후 캐싱 처리를 하는 등의 방식으로 개선하면 좋을것같아요~!

resolve: #160 
